### PR TITLE
branch change to openshift-3.10

### DIFF
--- a/groups/jenkins/repo.txt
+++ b/groups/jenkins/repo.txt
@@ -1,3 +1,3 @@
-export BRANCH=release-3.10
+export BRANCH=openshift-3.10
 export REPO=https://github.com/openshift/jenkins.git
 


### PR DESCRIPTION
The jenkins repo does not have a release-3.10 branch
and instead has only an openshift-3.10 branch.